### PR TITLE
Fix hashing issue in Python 3.9

### DIFF
--- a/pyanidb/hash.py
+++ b/pyanidb/hash.py
@@ -123,9 +123,9 @@ def hash_files(files, cache = False, algorithms = ('ed2k',), num_threads = 1):
 		thread = Hashthread(files, hashlist, algorithms, cache)
 		thread.start()
 		threads.append(thread)
-	while hashlist or sum([thread.isAlive() for thread in threads]):
+	while hashlist or sum([thread.is_alive() for thread in threads]):
 		try:
 			yield hashlist.pop(0)
 		except IndexError:
 			time.sleep(0.1)
-	raise StopIteration
+	return


### PR DESCRIPTION
Solves hashing problem described in #1.

- `Thread.isAlive()` was [deprecated](https://docs.python.org/3.8/whatsnew/3.8.html#deprecated) in Python 3.8.
- Raising `StopIteration` inside a generator replaces it with `RuntimeError` ([PEP 0479](https://www.python.org/dev/peps/pep-0479/))